### PR TITLE
Fix Virtualizer item height

### DIFF
--- a/src/scenarios/FluentVirtualizer.tsx
+++ b/src/scenarios/FluentVirtualizer.tsx
@@ -36,9 +36,9 @@ export const FluentVirtualizer = React.memo(() => {
         virtualizerLength={virtualizerLength}
         bufferItems={bufferItems}
         bufferSize={bufferSize}
-        itemSize={100}
+        itemSize={ROW_HEIGHT}
       >
-        {(index) => <Row key={index} index={index} />}
+        {(index) => <Row key={index} index={index} style={{height: ROW_HEIGHT}} />}
       </Virtualizer>
     </div>
   );


### PR DESCRIPTION
Item height was slightly inconsistent (32 vs 36) on some items.
Virtualizer itemSize was set to 100, should match ROW_HEIGHT